### PR TITLE
Added missing includes (Mac OS X Yosemite 10.10.2 / XCode 6.1.1)

### DIFF
--- a/TUIO/TuioServer.h
+++ b/TUIO/TuioServer.h
@@ -30,6 +30,7 @@
 #ifndef WIN32
 #include <netdb.h>
 #include <arpa/inet.h>
+#include <unistd.h>
 #endif
 
 namespace TUIO {

--- a/main.cpp
+++ b/main.cpp
@@ -1,6 +1,7 @@
 #include "tongseng.h"
 #include <iostream>
 #include <signal.h>
+#include <unistd.h>
 
 static bool running = false;
 static bool verbose = false;


### PR DESCRIPTION
Not really into cpp so I believe there should be some OS (or header file existence) test around the unistd.h include. Fixed the CLI tool build on Yosemite though. And the tool works fine.